### PR TITLE
Add ability to pass custom logger

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var url = require('url');
 var querystring = require('querystring');
 var chalk = require('chalk');
 var superagent = require('superagent');
+var util = require("util");
 
 exports = module.exports = function(options) {
   if(!options) options = {};
@@ -20,7 +21,9 @@ function attachSuperagentLogger(options, req) {
   var method = req.method;
 
   if(options.outgoing) {
-    console.log('%s %s %s %s %s %s',
+    var defaultOutgoingLogger = console.log;
+    var outgoingLogger = options.outgoingLogger || defaultOutgoingLogger;
+    outgoingLogger(util.format('%s %s %s %s %s %s',
       chalk.gray(
         rightPad(uri.protocol.toUpperCase().replace(/[^\w]/g, ''), 5)
       ),
@@ -29,7 +32,7 @@ function attachSuperagentLogger(options, req) {
       chalk.gray(' - '),
       chalk.gray(uri.href + (req.qs ? '' : '?' + querystring.encode(req.qs))),
       chalk.gray('(pending)')
-    );
+    ));
   }
 
   req.on('response', function(res) {
@@ -45,8 +48,10 @@ function attachSuperagentLogger(options, req) {
       st = chalk.red(st);
     }
 
+    var defaultResponseLogger = (body, status) => { console.log(body); };
+    var responseLogger = options.responseLogger || defaultResponseLogger;
 
-    console.log('%s %s %s %s %s %s',
+    responseLogger(util.format('%s %s %s %s %s %s',
       chalk.magenta(
         rightPad(uri.protocol.toUpperCase().replace(/[^\w]/g, ''), 5)
       ),
@@ -57,7 +62,7 @@ function attachSuperagentLogger(options, req) {
       chalk.gray('(') +
         chalk[colorForSpeed(elapsed)](elapsed + 'ms') +
         chalk.gray(')')
-    );
+    ), res.status);
   });
 }
 


### PR DESCRIPTION
Add ability to pass custom outgoing logger and response logger functions in cases when console.log is not sufficient. When no custom loggers are provided, it's used console.log default function. Outgoing logger is called with one "body" parameter. Response logger is called with "body" and "status" parameters, so client could distinguish between different log methods for different status codes.